### PR TITLE
JE-64453   [ Plesk ] error during intall the "tests" version: The ope…

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -97,8 +97,12 @@ onInstall:
       plesk bin admin --set-admin-password -passwd "${globals.passwd}"
       iptables -t nat -I PREROUTING -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 8443
       iptables-save
-      plesk bin ipmanage -r ${nodes.cp[0].intIP}
-      plesk bin ipmanage --reread
+      [[ "${settings.version}" != "tests" ]] && {
+        plesk bin ipmanage -r ${nodes.cp[0].intIP}
+        plesk bin ipmanage --reread
+      } || {
+        echo "OK"
+      }
       
 success: |
   **Admin URL:** [https://${env.domain}](https://${env.domain})   


### PR DESCRIPTION
…ration could not be performed. mesg: ttyname failed: Inappropriate ioctl for device\nThe license key is invalid.